### PR TITLE
Fix unbounded GET-MESSAGE in bobbio sample app

### DIFF
--- a/_posts/2017-01-29-libraries.md
+++ b/_posts/2017-01-29-libraries.md
@@ -1,7 +1,7 @@
 ---
 layout: post
 title: Source Code Organisation
-updated: 30/05/2017
+updated: 01/08/2018
 ---
 
 Answers to some commonly asked questions about how to organise Common Lisp code,
@@ -313,7 +313,7 @@ Put the following into `web.lisp`:
 (defvar *app* (make-instance 'ningle:<app>))
 
 (setf (ningle:route *app* "/")
-      get-message)
+      (get-message))
 
 (defun start-server ()
   (clack:clackup *app*))


### PR DESCRIPTION
Line 277 of commit 5318197 seems to have created the following regression when compiling the sample app:
```
The variable BOBBIO:GET-MESSAGE is unbound.
   [Condition of type UNBOUND-VARIABLE]
```
Encountered with SBCL 1.4.9.

Thank you @rmhsilva for the helpful site and excellent tutorial :+1:

Cheers!
